### PR TITLE
Specify parent group for byte-compile warning

### DIFF
--- a/minibuffer-stats.el
+++ b/minibuffer-stats.el
@@ -34,7 +34,8 @@
 
 (defgroup minibuffer-stats ()
   "Use the idle minibuffer window to display status information
-and optionally remove the modeline from view.")
+and optionally remove the modeline from view."
+  :group 'minibuffer)
 
 (defcustom minibuffer-stats-format nil
   "Specification of the contents of the minibuffer-line.


### PR DESCRIPTION
Fix following a warning.

```
minibuffer-stats.el:35:1:Warning: defgroup for ‘minibuffer-stats’ fails to
    specify containing group
```
